### PR TITLE
Move Python packages to requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ You can optionally add the Mastodon account's access token into the ini file. Al
 You'll need a few Python modules (which you can install into your global Python instance, or into a venv if you choose [outside the scope of this README]):
 
 ```
-pip install bs4
-pip install feedparser
-pip install requests
+pip install -r requirements.txt
 ```
 
 (use pip or pip3, as needed)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+bs4==0.0.*
+feedparser==6.0.*
+requests==2.22.*


### PR DESCRIPTION
It's very common in Python development to group pip packages, and their versions, into a `requirements.txt` file. This makes install dependencies (deps) a one-liner.

This also allows you to keep track of which versions of these deps will continue to work with your project.